### PR TITLE
Fix git clone URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
             sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             sudo chmod +x /usr/local/bin/docker-compose
-            git clone https://github.com/Shinichi1125/Pictionarizer.git
+            git clone https://github.com/Shinichi1125/pictionary_v2.1.git
             cd pictionary_v2.1
             set -x
             docker-compose build
@@ -39,7 +39,7 @@ jobs:
           command: |
             sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             sudo chmod +x /usr/local/bin/docker-compose
-            git clone https://github.com/Shinichi1125/Pictionarizer.git
+            git clone https://github.com/Shinichi1125/pictionary_v2.1.git
             cd pictionary_v2.1
             set -x
             docker-compose up -d


### PR DESCRIPTION
本来はdocker-compose.yaml一式をクローンするはずなのにPictionarizerをクローンしているという大失態を犯しました。すいません、マージよろしくおねがいします。。。