### PR TITLE
put latest tag to overwrite image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           command: |
             echo ${DOCKER_PASS} | docker login -u ${DOCKER_USER} --password-stdin
             docker images --format '{{.Repository}}' | while read imagename; do
-              docker push $imagename
+              docker push ${imagename}:latest
             done
 workflows:
   version: 2.1


### PR DESCRIPTION
Dockerhubのリポジトリ内のイメージを上書きするためにlatestタグを付けました。ちょっとこれでCircleCI再度回してみてほしいです。